### PR TITLE
Remove required Next function from route method

### DIFF
--- a/example/dart_express_example.dart
+++ b/example/dart_express_example.dart
@@ -12,7 +12,7 @@ main() {
   app.engine(JaelEngine.use());
   app.settings.viewEngine = 'mustache';
 
-  app.get('/', (req, res, _) {
+  app.get('/', (req, res) {
     res.statusCode = HttpStatus.ok;
 
     res.json({
@@ -21,43 +21,49 @@ main() {
     });
   });
 
-  app.all('/secret', (req, res, next) {
+  app.all('/secret', (req, res) {
     print('Accessing the secret section');
 
-    next();
+    req.next();
   });
 
-  app.get('/secret', (Request req, Response res, next) {
+  app.get('/secret', (req, res) {
     res.send('Secret Home Page');
   });
 
-  app.get('/2', (req, res, _) {
+  app.get('/secret/2', (req, res) {
+    res.send('Secret home page 2');
+  });
+
+  app.get('/2', (req, res) {
     res.render('index');
   });
 
-  app.get('/3', (req, res, _) {
+  app.get('/3', (req, res) {
     res.render('about', {
       'first_name': req.params['first_name'] ?? 'Devin Riegle',
       'person': req.params['person']
     });
   });
 
-  app.get('/4', (req, res, _) {
+  app.get('/4', (req, res) {
     res.render(
-        'test.jael', {'template_engine': 'Jael', 'first_name': 'Thosakwe'});
+      'test.jael',
+      {'template_engine': 'Jael', 'first_name': 'Thosakwe'},
+    );
   });
 
-  app.post('/post', (Request req, Response res, _) {
+  app.post('/post', (req, res) {
     res.send('Data from post :)');
   });
 
-  app.get('/users/:userId/posts/:postId', (req, res, _) {
+  app.get('/users/:userId/posts/:postId', (req, res) {
     print(req.params);
 
-    res.render('test.jl', {
-      'template_engine': req.params['postId'],
-      'first_name': 'George',
-    });
+    res.render(
+      'test.jael',
+      {'template_engine': req.params['postId'], 'first_name': 'George'},
+    );
   });
 
   app.listen(PORT, (int port) => print('Listening on port $port'));

--- a/lib/src/layer.dart
+++ b/lib/src/layer.dart
@@ -40,8 +40,8 @@ class Layer {
     return false;
   }
 
-  handleRequest(Request req, Response res, Next next) {
-    this.handle(req, res, next);
+  handleRequest(Request req, Response res) {
+    this.handle(req, res);
   }
 
   @override

--- a/lib/src/middleware/body_parser.dart
+++ b/lib/src/middleware/body_parser.dart
@@ -3,7 +3,7 @@ import 'package:dart_express/dart_express.dart';
 
 class BodyParser {
   static RouteMethod json() {
-    return (Request req, Response res, Function next) {
+    return (Request req, Response res) {
       var contentType = req.headers.contentType;
 
       if (req.method == 'POST' &&
@@ -12,10 +12,10 @@ class BodyParser {
         convertBodyToJson(req).then((Map<String, dynamic> json) {
           req.body = json;
 
-          next();
+          req?.next();
         });
       } else {
-        next();
+        req?.next();
       }
     };
   }

--- a/lib/src/middleware/init.dart
+++ b/lib/src/middleware/init.dart
@@ -4,7 +4,7 @@ import 'package:dart_express/src/response.dart';
 class Middleware {
   static final String name = 'EXPRESS_INIT';
 
-  static init(Request req, Response res, Function next) {
-    next();
+  static init(Request req, Response res) {
+    req?.next();
   }
 }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -2,8 +2,11 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:dart_express/src/route.dart';
+
 class Request extends HttpRequest {
   HttpRequest request;
+  Next _next;
   Map<String, dynamic> _body;
   Map<String, dynamic> params;
 
@@ -13,6 +16,8 @@ class Request extends HttpRequest {
 
   get body => this._body;
   set body(newBody) => this._body = newBody;
+  set next(Next next) => this._next = next;
+  get next => this._next;
 
   @override
   Future<bool> any(bool Function(Uint8List element) test) {

--- a/lib/src/route.dart
+++ b/lib/src/route.dart
@@ -3,7 +3,7 @@ import 'package:dart_express/src/request.dart';
 import 'package:dart_express/src/response.dart';
 
 typedef Next = Function();
-typedef RouteMethod = Function(Request req, Response res, Next next);
+typedef RouteMethod = Function(Request req, Response res);
 
 class Route {
   final String path;
@@ -12,7 +12,7 @@ class Route {
 
   Route(this.path);
 
-  dispatch(Request req, Response res, Next next) {}
+  dispatch(Request req, Response res) {}
 
   delete(RouteMethod cb) {
     this._setLayer('delete', cb);

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -32,7 +32,7 @@ class Router {
     return route;
   }
 
-  Router use(Function cb) {
+  Router use(RouteMethod cb) {
     var layer = Layer('/', handle: cb, name: Middleware.name);
 
     this.stack.add(layer);
@@ -45,7 +45,7 @@ class Router {
     var stack = self.stack;
     var index = 0;
 
-    next() {
+    req.next = () {
       String path = req.requestedUri.path;
       String method = req.method;
 
@@ -69,16 +69,16 @@ class Router {
 
         req.params.addAll(layer.routeParams);
 
-        route.stack.first.handleRequest(req, res, next);
+        route.stack.first.handleRequest(req, res);
       }
 
       // Matched without a route (Initial Middleware)
       if (match && route == null) {
-        layer.handleRequest(req, res, next);
+        layer.handleRequest(req, res);
       }
-    }
+    };
 
-    next();
+    req.next();
   }
 
   matchLayer(Layer layer, String path, String method) {

--- a/test/layer_test.dart
+++ b/test/layer_test.dart
@@ -92,7 +92,7 @@ void main() {
     test('calls the handler method with the expected values', () {
       bool called = false;
 
-      mockHandler(Request request, Response res, Function next) {
+      mockHandler(Request request, Response res) {
         called = true;
       }
 
@@ -101,7 +101,7 @@ void main() {
       var req = Request(null);
       var res = Response(null, null);
 
-      layer.handleRequest(req, res, () {});
+      layer.handleRequest(req, res);
 
       expect(called, isTrue);
     });


### PR DESCRIPTION
This PR removes the `Next` param from the route method.

Currently you need to provide a third param (`Next`) each time you define your routes like this:

```dart
app.get('/', (req, res, _) {
});

app.post('/users', (req, res, next) {
});
```

Since Dart does not support Union typedefs for Functions, there was no way to make the route handle optionally provide the `next` param.

I've updated the request object to store the `next` function for now as a workaround until union typedefs are added to Dart. https://github.com/dart-lang/language/issues/65

After this is merged, you'll be able to use the next param like this:

```dart
app.get('/', (req, res) {
  print('Here is some middleware that needs to run');
  req.next();
});
```